### PR TITLE
Keep extra surfaces (and _BATCHID input information composition)

### DIFF
--- a/COLLADASaxFrameworkLoader/src/COLLADASaxFWLMeshLoader.cpp
+++ b/COLLADASaxFrameworkLoader/src/COLLADASaxFWLMeshLoader.cpp
@@ -215,7 +215,8 @@ namespace COLLADASaxFWL
         }
         else
         {
-            batchids.setData ( valuesArray.getData (), valuesArray.getCount () );
+            batchids.setData ( valuesArray.getData (), valuesArray.getCount (), source->getId(),
+			                   (size_t) source->getStride());
             valuesArray.yieldOwnerShip();
         }
 


### PR DESCRIPTION
This PR makes all samplers referenced in an effect be carried over to the end `COLLADAFW::IWriter`, which supports the case of e.g. bump mapped textures that are only referenced in `<extra>` data.

The downside is that if multiple profiles are specified, this will include all textures in all profiles, instead of only matching them in on-demand, but since for our application we only have a single profile, this isn't an issue.